### PR TITLE
Exit immediately on error

### DIFF
--- a/installjava
+++ b/installjava
@@ -1,6 +1,7 @@
 #!/data/data/com.termux/files/usr/bin/bash
 
 #Setup
+set -e
 shopt -s expand_aliases
 alias ee='echo -e'
 
@@ -32,31 +33,31 @@ else
 	*)
 		ee "\e[91mERROR: Unknown architecture."; echo; exit ;;
 	esac
-	
+
 	#Actual installation
 	ee "\e[32m[*] \e[34mDownloading JDK-8 (~70Mb) for ${archname}...  🕛This will take some time, so better make a coffee.🕛"
 	wget https://github.com/Hax4us/java/releases/download/${tag}/jdk8_${archname}.tar.gz -q
-	
+
 	ee "\e[32m[*] \e[34mMoving JDK to system..."
 	mv jdk8_${archname}.tar.gz $PREFIX/share
-	
+
 	ee "\e[32m[*] \e[34mExtracting JDK..."
 	cd $PREFIX/share
 	tar -xhf jdk8_${archname}.tar.gz
-	
+
 	ee "\e[32m[*] \e[34mSeting-up %JAVA_HOME%..."
 	export JAVA_HOME=$PREFIX/share/jdk8
 	echo "export JAVA_HOME=$PREFIX/share/jdk8" >> $HOME/.profile
-	
+
 	ee "\e[32m[*] \e[34mCoping Java wrapper scripts to bin..."
 	#I'm not 100% sure, but getting rid of bin contnent MAY cause some issues with %JAVA_HOME%, thus it's no longer moved - copied instead. Sorry to everyone short on storage.
 	cp bin/* $PREFIX/bin
-	
+
 	ee "\e[32m[*] \e[34mCleaning up temporary files..."
 	rm -rf $HOME/installjava
 	rm -rf $PREFIX/share/jdk8_${archname}.tar.gz
 	rm -rf $PREFIX/share/bin
-	
+
 	echo
 	ee "\e[32mJava was successfully installed!\e[39m"
 	echo "Enjoy your new, tasty Java :D (and a coffee, if you didn't drink it yet)"


### PR DESCRIPTION
Added ` set -e ` to exit immediately on error. For example, I didn't have `wget` installed but script still continued and gave false success message.